### PR TITLE
Feature/has no x

### DIFF
--- a/bulwark/checks.py
+++ b/bulwark/checks.py
@@ -61,12 +61,12 @@ def has_columns(df, columns, exact_cols=False, exact_order=False):
 
 
 def has_no_x(df, values=None, columns=None):
-    """Asserts that there are no user specified values in `df`.
+    """Asserts that there are no user-specified `values` in `df`'s `columns`.
 
     Args:
         df (pd.DataFrame): Any pd.DataFrame.
         values (list): A list of values to check for in the pd.DataFrame.
-        columns (list): A subset of columns to check for np.nans.
+        columns (list): A subset of columns to check for `values`.
 
     Returns:
         Original `df`.
@@ -108,7 +108,7 @@ def has_no_nones(df, columns=None):
 
     Args:
         df (pd.DataFrame): Any pd.DataFrame.
-        columns (list): A subset of columns to check for np.nans.
+        columns (list): A subset of columns to check for Nones.
 
     Returns:
         Original `df`.
@@ -124,7 +124,7 @@ def has_no_infs(df, columns=None):
 
     Args:
         df (pd.DataFrame): Any pd.DataFrame.
-        columns (list): A subset of columns to check for np.nans.
+        columns (list): A subset of columns to check for np.infs.
 
     Returns:
         Original `df`.
@@ -140,7 +140,7 @@ def has_no_neg_infs(df, columns=None):
 
     Args:
         df (pd.DataFrame): Any pd.DataFrame.
-        columns (list): A subset of columns to check for np.nans.
+        columns (list): A subset of columns to check for -np.infs.
 
     Returns:
         Original `df`.

--- a/bulwark/checks.py
+++ b/bulwark/checks.py
@@ -60,8 +60,35 @@ def has_columns(df, columns, exact_cols=False, exact_order=False):
     return df
 
 
+def has_no_x(df, values=None, columns=None):
+    """Asserts that there are no user specified values in `df`.
+
+    Args:
+        df (pd.DataFrame): Any pd.DataFrame.
+        values (list): A list of values to check for in the pd.DataFrame.
+        columns (list): A subset of columns to check for np.nans.
+
+    Returns:
+        Original `df`.
+
+    """
+    values = values if values is not None else []
+    columns = columns if columns is not None else df.columns
+
+    try:
+        assert not df[columns].isin(values).values.any()
+    except AssertionError as e:
+        missing = df[columns].isin(values)
+        msg = bad_locations(missing)
+        e.args = msg
+        raise
+    return df
+
+
 def has_no_nans(df, columns=None):
     """Asserts that there are no np.nans in `df`.
+
+    This is a convenience wrapper for `has_no_x`.
 
     Args:
         df (pd.DataFrame): Any pd.DataFrame.
@@ -71,21 +98,30 @@ def has_no_nans(df, columns=None):
         Original `df`.
 
     """
-    if columns is None:
-        columns = df.columns
-    try:
-        assert not df[columns].isnull().values.any()
-    except AssertionError as e:
-        missing = df[columns].isnull()
-        msg = bad_locations(missing)
-        e.args = msg
-        raise
-    return df
+    return has_no_x(df, values=[np.nan], columns=columns)
+
+
+def has_no_nones(df, columns=None):
+    """Asserts that there are no Nones in `df`.
+
+    This is a convenience wrapper for `has_no_x`.
+
+    Args:
+        df (pd.DataFrame): Any pd.DataFrame.
+        columns (list): A subset of columns to check for np.nans.
+
+    Returns:
+        Original `df`.
+
+    """
+    return has_no_x(df, values=[None], columns=columns)
 
 
 def has_no_infs(df, columns=None):
     """Asserts that there are no np.infs in `df`.
 
+    This is a convenience wrapper for `has_no_x`.
+
     Args:
         df (pd.DataFrame): Any pd.DataFrame.
         columns (list): A subset of columns to check for np.nans.
@@ -94,21 +130,14 @@ def has_no_infs(df, columns=None):
         Original `df`.
 
     """
-    if columns is None:
-        columns = df.columns
-    try:
-        assert not df[columns].isin([np.inf]).values.any()
-    except AssertionError as e:
-        missing = df[columns].isin([np.inf])
-        msg = bad_locations(missing)
-        e.args = msg
-        raise
-    return df
+    return has_no_x(df, values=[np.inf], columns=columns)
 
 
 def has_no_neg_infs(df, columns=None):
     """Asserts that there are no np.infs in `df`.
 
+    This is a convenience wrapper for `has_no_x`.
+
     Args:
         df (pd.DataFrame): Any pd.DataFrame.
         columns (list): A subset of columns to check for np.nans.
@@ -117,16 +146,7 @@ def has_no_neg_infs(df, columns=None):
         Original `df`.
 
     """
-    if columns is None:
-        columns = df.columns
-    try:
-        assert not df[columns].isin([-np.inf]).values.any()
-    except AssertionError as e:
-        missing = df[columns].isin([np.inf])
-        msg = bad_locations(missing)
-        e.args = msg
-        raise
-    return df
+    return has_no_x(df, values=[-np.inf], columns=columns)
 
 
 def has_unique_index(df):

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -62,6 +62,17 @@ def test_is_shape():
         dc.IsShape(shape=(9, 2), cheese=True)(_add_n)(df)  # bad dc param check
 
 
+def test_has_no_x():
+    df = pd.DataFrame([1, 2, 3], index=['a', 'b', 'c'])
+    result = ck.has_no_x(df, values=['x', 'y', 'z'])
+    tm.assert_frame_equal(df, result)
+
+    result = dc.HasNoX()(_add_n)(df, 2)
+    tm.assert_frame_equal(result, df + 2)
+    result = dc.HasNoX()(_add_n)(df, n=2)
+    tm.assert_frame_equal(result, df + 2)
+
+
 def test_has_no_nans():
     df = pd.DataFrame(np.random.randn(5, 3))
     result = ck.has_no_nans(df)
@@ -70,6 +81,39 @@ def test_has_no_nans():
     result = dc.HasNoNans()(_add_n)(df, 2)
     tm.assert_frame_equal(result, df + 2)
     result = dc.HasNoNans()(_add_n)(df, n=2)
+    tm.assert_frame_equal(result, df + 2)
+
+
+def test_has_no_nones():
+    df = pd.DataFrame(np.random.randn(5, 3))
+    result = ck.has_no_nones(df)
+    tm.assert_frame_equal(df, result)
+
+    result = dc.HasNoNones()(_add_n)(df, 2)
+    tm.assert_frame_equal(result, df + 2)
+    result = dc.HasNoNones()(_add_n)(df, n=2)
+    tm.assert_frame_equal(result, df + 2)
+
+
+def test_has_no_infs():
+    df = pd.DataFrame(np.random.randn(5, 3))
+    result = ck.has_no_infs(df)
+    tm.assert_frame_equal(df, result)
+
+    result = dc.HasNoInfs()(_add_n)(df, 2)
+    tm.assert_frame_equal(result, df + 2)
+    result = dc.HasNoInfs()(_add_n)(df, n=2)
+    tm.assert_frame_equal(result, df + 2)
+
+
+def test_has_no_neg_infs():
+    df = pd.DataFrame(np.random.randn(5, 3))
+    result = ck.has_no_neg_infs(df)
+    tm.assert_frame_equal(df, result)
+
+    result = dc.HasNoNegInfs()(_add_n)(df, 2)
+    tm.assert_frame_equal(result, df + 2)
+    result = dc.HasNoNegInfs()(_add_n)(df, n=2)
     tm.assert_frame_equal(result, df + 2)
 
 


### PR DESCRIPTION
This PR adds the check `has_no_x`. Other checks `has_no_nans`, `has_no_infs`, `has_no_neg_infs` were refactored as convenience wrappers for `has_no_x`.

Additionally, the older `has_no_nans` function used `pd.isnull()` to check for missing values in the function (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.isnull.html). This would return true for both `np.nan` and `None` values. Now, `has_no_nans` explicitly checks for `np.nan`. A new check `has_no_nones` was added to explicitly checks for `None`.