### PR TITLE
Deprecated old functions (fixes issue #34)

### DIFF
--- a/bulwark/checks.py
+++ b/bulwark/checks.py
@@ -91,7 +91,7 @@ def has_no_x(df, values=None, columns=None):
 
 def none_missing(df, columns=None):
     """Deprecated: Replaced with has_no_nans"""
-    warnings.warn("This function has been renamed to has_no_nans. The old name will be removed in 0.7",
+    warnings.warn("This function has been renamed to has_no_nans. The old name will be removed in 0.7.",
                   DeprecationWarning,
                   stacklevel=1)
 
@@ -202,7 +202,7 @@ def has_set_within_vals(df, items):
 
 def unique_index(df):
     """Deprecated: Replaced with has_unique_index"""
-    warnings.warn("This function has been renamed to hasunique_index. The old name will be removed in 0.7",
+    warnings.warn("This function has been renamed to hasunique_index. The old name will be removed in 0.7.",
                   DeprecationWarning,
                   stacklevel=1)
 
@@ -308,14 +308,15 @@ def unique(df, columns=None):
             raise AssertionError("Column {!r} contains non-unique values".format(col))
     return df
 
+
 def within_set(df, items=None):
     """Deprecated: replaced with has_vals_within_set"""
-    warnings.warn("This function has been renamed to has_vals_within_set. The old name will be removed in 0.7",
+    warnings.warn("This function has been renamed to has_vals_within_set. The old name will be removed in 0.7.",
                   DeprecationWarning,
                   stacklevel=1)
 
     return has_vals_within_set(df, items)
-    
+
 
 def has_vals_within_set(df, items=None):
     """Asserts that `df` is a subset of items.
@@ -338,11 +339,12 @@ def has_vals_within_set(df, items=None):
 
 def within_range(df, items=None):
     """Deprecated: Replaced with has_vals_within_range"""
-    warnings.warn("This function has been renamed to has_vals_within_range. The old name will be removed in 0.7",
+    warnings.warn("This function has been renamed to has_vals_within_range. The old name will be removed in 0.7.",
                   DeprecationWarning,
                   stacklevel=1)
 
     return has_vals_within_range(df, items)
+
 
 def has_vals_within_range(df, items=None):
     """Asserts that `df` is within a range.
@@ -365,7 +367,7 @@ def has_vals_within_range(df, items=None):
 
 def within_n_std(df, n=3):
     """Deprecated: replaced with has_vals_within_n_std"""
-    warnings.warn("This function has been renamed to has_vals_within_n_std. The old name will be removed in 0.7",
+    warnings.warn("This function has been renamed to has_vals_within_n_std. The old name will be removed in 0.7.",
                   DeprecationWarning,
                   stacklevel=1)
 

--- a/bulwark/checks.py
+++ b/bulwark/checks.py
@@ -91,12 +91,11 @@ def has_no_x(df, values=None, columns=None):
 
 def none_missing(df, columns=None):
     """Deprecated: Replaced with has_no_nans"""
-    warnings.warn("This function has been renamed to has_no_nans. The old name will be removed in 0.7. "
-                  "Switch to the from_hierarchy_id method for identical functionality.",
+    warnings.warn("This function has been renamed to has_no_nans. The old name will be removed in 0.7",
                   DeprecationWarning,
                   stacklevel=1)
 
-    has_no_nans(df, columns)
+    return has_no_nans(df, columns)
 
 
 def has_no_nans(df, columns=None):
@@ -203,12 +202,11 @@ def has_set_within_vals(df, items):
 
 def unique_index(df):
     """Deprecated: Replaced with has_unique_index"""
-    warnings.warn("This function has been renamed to hasunique_index. The old name will be removed in 0.7. "
-                  "Switch to the from_hierarchy_id method for identical functionality.",
+    warnings.warn("This function has been renamed to hasunique_index. The old name will be removed in 0.7",
                   DeprecationWarning,
                   stacklevel=1)
 
-    has_unique_index(df)
+    return has_unique_index(df)
 
 
 def has_unique_index(df):
@@ -312,12 +310,11 @@ def unique(df, columns=None):
 
 def within_set(df, items=None):
     """Deprecated: replaced with has_vals_within_set"""
-    warnings.warn("This function has been renamed to has_vals_within_set. The old name will be removed in 0.7. "
-                  "Switch to the from_hierarchy_id method for identical functionality.",
+    warnings.warn("This function has been renamed to has_vals_within_set. The old name will be removed in 0.7",
                   DeprecationWarning,
                   stacklevel=1)
 
-    has_vals_within_set(df, items)
+    return has_vals_within_set(df, items)
     
 
 def has_vals_within_set(df, items=None):
@@ -341,12 +338,11 @@ def has_vals_within_set(df, items=None):
 
 def within_range(df, items=None):
     """Deprecated: Replaced with has_vals_within_range"""
-    warnings.warn("This function has been renamed to has_vals_within_range. The old name will be removed in 0.7. "
-                  "Switch to the from_hierarchy_id method for identical functionality.",
+    warnings.warn("This function has been renamed to has_vals_within_range. The old name will be removed in 0.7",
                   DeprecationWarning,
                   stacklevel=1)
 
-    has_vals_within_range(df, items)
+    return has_vals_within_range(df, items)
 
 def has_vals_within_range(df, items=None):
     """Asserts that `df` is within a range.
@@ -369,12 +365,11 @@ def has_vals_within_range(df, items=None):
 
 def within_n_std(df, n=3):
     """Deprecated: replaced with has_vals_within_n_std"""
-    warnings.warn("This function has been renamed to has_vals_within_n_std. The old name will be removed in 0.7. "
-                  "Switch to the from_hierarchy_id method for identical functionality.",
+    warnings.warn("This function has been renamed to has_vals_within_n_std. The old name will be removed in 0.7",
                   DeprecationWarning,
                   stacklevel=1)
 
-    has_vals_within_n_std(df, n)
+    return has_vals_within_n_std(df, n)
 
 
 def has_vals_within_n_std(df, n=3):

--- a/bulwark/checks.py
+++ b/bulwark/checks.py
@@ -11,8 +11,12 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 import six
+import warnings
 
 from bulwark.generic import bad_locations
+
+# Required for DeprecationWarnings to not be ignored
+warnings.simplefilter('always', DeprecationWarning)
 
 
 def has_columns(df, columns, exact_cols=False, exact_order=False):
@@ -83,6 +87,16 @@ def has_no_x(df, values=None, columns=None):
         e.args = msg
         raise
     return df
+
+
+def none_missing(df, columns=None):
+    """Deprecated: Replaced with has_no_nans"""
+    warnings.warn("This function has been renamed to has_no_nans. The old name will be removed in 0.7. "
+                  "Switch to the from_hierarchy_id method for identical functionality.",
+                  DeprecationWarning,
+                  stacklevel=1)
+
+    has_no_nans(df, columns)
 
 
 def has_no_nans(df, columns=None):
@@ -187,6 +201,16 @@ def has_set_within_vals(df, items):
     return df
 
 
+def unique_index(df):
+    """Deprecated: Replaced with has_unique_index"""
+    warnings.warn("This function has been renamed to hasunique_index. The old name will be removed in 0.7. "
+                  "Switch to the from_hierarchy_id method for identical functionality.",
+                  DeprecationWarning,
+                  stacklevel=1)
+
+    has_unique_index(df)
+
+
 def has_unique_index(df):
     """Asserts that `df`'s index is unique.
 
@@ -286,8 +310,17 @@ def unique(df, columns=None):
             raise AssertionError("Column {!r} contains non-unique values".format(col))
     return df
 
-
 def within_set(df, items=None):
+    """Deprecated: replaced with has_vals_within_set"""
+    warnings.warn("This function has been renamed to has_vals_within_set. The old name will be removed in 0.7. "
+                  "Switch to the from_hierarchy_id method for identical functionality.",
+                  DeprecationWarning,
+                  stacklevel=1)
+
+    has_vals_within_set(df, items)
+    
+
+def has_vals_within_set(df, items=None):
     """Asserts that `df` is a subset of items.
 
     Args:
@@ -307,6 +340,15 @@ def within_set(df, items=None):
 
 
 def within_range(df, items=None):
+    """Deprecated: Replaced with has_vals_within_range"""
+    warnings.warn("This function has been renamed to has_vals_within_range. The old name will be removed in 0.7. "
+                  "Switch to the from_hierarchy_id method for identical functionality.",
+                  DeprecationWarning,
+                  stacklevel=1)
+
+    has_vals_within_range(df, items)
+
+def has_vals_within_range(df, items=None):
     """Asserts that `df` is within a range.
 
     Args:
@@ -326,6 +368,16 @@ def within_range(df, items=None):
 
 
 def within_n_std(df, n=3):
+    """Deprecated: replaced with has_vals_within_n_std"""
+    warnings.warn("This function has been renamed to has_vals_within_n_std. The old name will be removed in 0.7. "
+                  "Switch to the from_hierarchy_id method for identical functionality.",
+                  DeprecationWarning,
+                  stacklevel=1)
+
+    has_vals_within_n_std(df, n)
+
+
+def has_vals_within_n_std(df, n=3):
     """Asserts that every value is within ``n`` standard deviations of its column's mean.
 
     Args:

--- a/docs/bulwark.checks.rst
+++ b/docs/bulwark.checks.rst
@@ -25,9 +25,9 @@ bulwark.checks
       multi_check
       one_to_many
       unique
-      within_n_std
-      within_range
-      within_set
+      has_vals_within_n_std
+      has_vals_within_range
+      has_vals_within_set
    
    
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -280,43 +280,43 @@ def test_monotonic_items():
         df), df + 1)
 
 
-def test_within_set():
+def test_has_vals_within_set():
     df = pd.DataFrame({'A': [1, 2, 3], 'B': ['a', 'b', 'c']})
     items = {'A': [1, 2, 3], 'B': ['a', 'b', 'c']}
-    tm.assert_frame_equal(df, ck.within_set(df, items))
+    tm.assert_frame_equal(df, ck.has_vals_within_set(df, items))
     tm.assert_frame_equal(df, dc.WithinSet(items=items)(_noop)(df))
 
     items.pop('A')
-    tm.assert_frame_equal(df, ck.within_set(df, items))
+    tm.assert_frame_equal(df, ck.has_vals_within_set(df, items))
     tm.assert_frame_equal(df, dc.WithinSet(items=items)(_noop)(df))
 
     items['A'] = [1, 2]
     with pytest.raises(AssertionError):
-        ck.within_set(df, items)
+        ck.has_vals_within_set(df, items)
     with pytest.raises(AssertionError):
         dc.WithinSet(items=items)(_noop)(df)
 
 
-def test_within_range():
+def test_has_vals_within_range():
     df = pd.DataFrame({'A': [-1, 0, 1]})
     items = {'A': (-1, 1)}
-    tm.assert_frame_equal(df, ck.within_range(df, items))
+    tm.assert_frame_equal(df, ck.has_vals_within_range(df, items))
     tm.assert_frame_equal(df, dc.WithinRange(items)(_noop)(df))
 
     items['A'] = (0, 1)
     with pytest.raises(AssertionError):
-        ck.within_range(df, items)
+        ck.has_vals_within_range(df, items)
     with pytest.raises(AssertionError):
         dc.WithinRange(items)(_noop)(df)
 
 
-def test_within_n_std():
+def test_has_vals_within_n_std():
     df = pd.DataFrame({'A': np.arange(10), 'B': list('abcde') * 2})
-    tm.assert_frame_equal(df, ck.within_n_std(df))
+    tm.assert_frame_equal(df, ck.has_vals_within_n_std(df))
     tm.assert_frame_equal(df, dc.WithinNStd()(_noop)(df))
 
     with pytest.raises(AssertionError):
-        ck.within_n_std(df, .5)
+        ck.has_vals_within_n_std(df, .5)
     with pytest.raises(AssertionError):
         dc.WithinNStd(.5)(_noop)(df)
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -83,15 +83,19 @@ def test_has_no_nans():
     result = dc.HasNoNans()(_add_n)(df, n=2)
     tm.assert_frame_equal(result, df + 2)
 
-    
+
 def test_none_missing():
     df = pd.DataFrame(np.random.randn(5, 3))
-    result = ck.none_missing(df)
+    with pytest.deprecated_call():
+        result = ck.none_missing(df)
     tm.assert_frame_equal(df, result)
 
-    result = dc.NoneMissing()(_add_n)(df, 2)
+    with pytest.deprecated_call():
+        result = dc.NoneMissing()(_add_n)(df, 2)
     tm.assert_frame_equal(result, df + 2)
-    result = dc.NoneMissing()(_add_n)(df, n=2)
+
+    with pytest.deprecated_call():
+        result = dc.NoneMissing()(_add_n)(df, n=2)
     tm.assert_frame_equal(result, df + 2)
 
 
@@ -183,13 +187,17 @@ def test_has_unique_index():
 
 def test_unique_index():
     df = pd.DataFrame([1, 2, 3], index=['a', 'b', 'c'])
-    tm.assert_frame_equal(df, ck.unique_index(df))
-    result = dc.UniqueIndex()(_add_n)(df)
+
+    with pytest.deprecated_call():
+        tm.assert_frame_equal(df, ck.unique_index(df))
+
+    with pytest.deprecated_call():
+        result = dc.UniqueIndex()(_add_n)(df)
     tm.assert_frame_equal(result, df + 1)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError), pytest.deprecated_call():
         ck.unique_index(df.reindex(['a', 'a', 'b']))
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError), pytest.deprecated_call():
         dc.UniqueIndex()(_add_n)(df.reindex(['a', 'a', 'b']))
 
 
@@ -306,19 +314,23 @@ def test_monotonic_items():
 def test_within_set():
     df = pd.DataFrame({'A': [1, 2, 3], 'B': ['a', 'b', 'c']})
     items = {'A': [1, 2, 3], 'B': ['a', 'b', 'c']}
-    tm.assert_frame_equal(df, ck.within_set(df, items))
-    tm.assert_frame_equal(df, dc.WithinSet(items=items)(_noop)(df))
+
+    with pytest.deprecated_call():
+        tm.assert_frame_equal(df, ck.within_set(df, items))
+        tm.assert_frame_equal(df, dc.WithinSet(items=items)(_noop)(df))
 
     items.pop('A')
-    tm.assert_frame_equal(df, ck.within_set(df, items))
-    tm.assert_frame_equal(df, dc.WithinSet(items=items)(_noop)(df))
+    with pytest.deprecated_call():
+        tm.assert_frame_equal(df, ck.within_set(df, items))
+        tm.assert_frame_equal(df, dc.WithinSet(items=items)(_noop)(df))
 
     items['A'] = [1, 2]
-    with pytest.raises(AssertionError):
-        ck.has_vals_within_set(df, items)
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError), pytest.deprecated_call():
+        ck.within_set(df, items)
+    with pytest.raises(AssertionError), pytest.deprecated_call():
         dc.WithinSet(items=items)(_noop)(df)
-    
+
+
 def test_has_vals_within_set():
     df = pd.DataFrame({'A': [1, 2, 3], 'B': ['a', 'b', 'c']})
     items = {'A': [1, 2, 3], 'B': ['a', 'b', 'c']}
@@ -333,7 +345,7 @@ def test_has_vals_within_set():
     with pytest.raises(AssertionError):
         ck.has_vals_within_set(df, items)
     with pytest.raises(AssertionError):
-        dc.WithinSet(items=items)(_noop)(df)
+        dc.HasValsWithinSet(items=items)(_noop)(df)
 
 
 def test_has_vals_within_range():
@@ -352,13 +364,15 @@ def test_has_vals_within_range():
 def test_within_range():
     df = pd.DataFrame({'A': [-1, 0, 1]})
     items = {'A': (-1, 1)}
-    tm.assert_frame_equal(df, ck.within_range(df, items))
-    tm.assert_frame_equal(df, dc.WithinRange(items)(_noop)(df))
+
+    with pytest.deprecated_call():
+        tm.assert_frame_equal(df, ck.within_range(df, items))
+        tm.assert_frame_equal(df, dc.WithinRange(items)(_noop)(df))
 
     items['A'] = (0, 1)
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError), pytest.deprecated_call():
         ck.within_range(df, items)
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError), pytest.deprecated_call():
         dc.WithinRange(items)(_noop)(df)
 
 
@@ -375,12 +389,14 @@ def test_has_vals_within_n_std():
 
 def test_within_n_std():
     df = pd.DataFrame({'A': np.arange(10), 'B': list('abcde') * 2})
-    tm.assert_frame_equal(df, ck.within_n_std(df))
-    tm.assert_frame_equal(df, dc.WithinNStd()(_noop)(df))
 
-    with pytest.raises(AssertionError):
+    with pytest.deprecated_call():
+        tm.assert_frame_equal(df, ck.within_n_std(df))
+        tm.assert_frame_equal(df, dc.WithinNStd()(_noop)(df))
+
+    with pytest.raises(AssertionError), pytest.deprecated_call():
         ck.within_n_std(df, .5)
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError), pytest.deprecated_call():
         dc.WithinNStd(.5)(_noop)(df)
 
 


### PR DESCRIPTION
Fixes issue #34 

Renames and deprecates the following functions:
within_set -> has_vals_within_set
within_range -> has_vals_within_range
within_n_std -> has_vals_within_n_std

Adds deprecation warning and wrapper for the following functions:
none_missing became has_no_nans
unique_index became has_unique_index