### PR TITLE
hotfix docs building issue by pinning Sphinx v2.x.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ with open("README.md") as readme_file:
 # Requirements placed here for convenient viewing
 install_requires = ['numpy>=1.15', 'pandas>=0.23.0']
 tests_requires = ["pytest", "pytest-cov"]
-docs_requires = ["m2r", "setuptools>=30.4", "Sphinx", "sphinx_rtd_theme"]
+# Upgrading to Sphinx 3.x.x requires m2r
+# to merge this pr: https://github.com/miyakogi/m2r/pull/55
+docs_requires = ["m2r", "setuptools>=30.4", "Sphinx~=2.0", "sphinx_rtd_theme"]
 dev_requires = tests_requires + docs_requires + ["pre-commit", "tox"]
 
 name = project_info.NAME

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, py35, py36, py37, docs, coverage-report
+envlist = lint, py36, py37, py38, docs, coverage-report
 skip_missing_interpreters=True
 
 [travis]


### PR DESCRIPTION
Have to pin Sphinx to v2.x.x, because upgrading to 3.x.x requires m2r to merge this pr: https://github.com/miyakogi/m2r/pull/55