### PR TITLE
Update license classifier in setup.py to match LICENSE

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     author_email="zaxr@protonmail.com",
     classifiers=["Development Status :: 4 - Beta",
                  "Intended Audience :: Developers",
-                 "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+                 "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
                  "Natural Language :: English",
                  "Programming Language :: Python :: 3",
                  "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
I've assumed it's LGPL 3.0 only, rather than "or later", since that's more conservative.
https://github.com/ZaxR/bulwark/commit/45d690b98488c4fef417e2223f6ad0ee29278a6d